### PR TITLE
Added hash function for NDTime and EIRational classes

### DIFF
--- a/include/EIRational.hpp
+++ b/include/EIRational.hpp
@@ -125,6 +125,12 @@ class EIRational {
       
       return to_string(_value.numerator()) + "/" + to_string(_value.denominator());  
     }
+
+    // a useful general-purpose accessor
+    auto as_tuple() const {
+        return std::make_tuple(_inf, _possitive, _value);
+    }
+
 };
 
 inline EIRational operator+(const EIRational lhs, const EIRational& rhs) noexcept {
@@ -241,5 +247,14 @@ namespace std {
     static constexpr bool tinyness_before = false;
   };
 }
+
+// hash_value implemented in terms of tuple, for consistency and simplicity
+std::size_t hash_value(const EIRational& t) {
+    return boost::hash_value(t.as_tuple());
+}
+
+// specialize hash
+template<>
+struct std::hash<EIRational> : boost::hash<EIRational> {};
 
 #endif // EIRATIONAL_HPP

--- a/include/NDTime.hpp
+++ b/include/NDTime.hpp
@@ -21,10 +21,13 @@
 
 #include <iostream>
 #include <string>
+#include <tuple>
 #include <vector>
 #include <cmath>
 #include <cstdlib>
 #include <boost/algorithm/string.hpp>
+#include <boost/functional/hash.hpp>
+
 
 class NDTime {
 private:
@@ -514,6 +517,12 @@ public:
   		return _femtoseconds;
   	}
 
+    // a useful general-purpose accessor
+  	auto as_tuple() const {
+        return std::make_tuple(_inf, _possitive, _hours, _minutes, _seconds, _milliseconds,
+                               _microseconds, _nanoseconds, _picoseconds, _femtoseconds);
+    }
+
     friend std::ostream& operator<<(std::ostream& os, const NDTime& t);
     friend std::istream& operator>>(std::istream& is, NDTime& t);
 };
@@ -558,6 +567,7 @@ namespace std {
 
         static constexpr int  digits = numeric_limits<int>::digits;
         static constexpr int  digits10 = numeric_limits<int>::digits10;
+        static constexpr int  max_digits10 = numeric_limits<int>::max_digits10;
         static constexpr bool is_signed = true;
         static constexpr bool is_integer = false;
         static constexpr bool is_exact = true;
@@ -583,5 +593,14 @@ namespace std {
         static constexpr bool tinyness_before = false;
     };
 }
+
+// hash_value implemented in terms of tuple, for consistency and simplicity
+std::size_t hash_value(const NDTime& t) {
+    return boost::hash_value(t.as_tuple());
+}
+
+// specialize hash
+template<>
+struct std::hash<NDTime> : boost::hash<NDTime> {};
 
 #endif

--- a/test/ndtime_test.cpp
+++ b/test/ndtime_test.cpp
@@ -16,6 +16,7 @@
  */
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
+#include <unordered_map>
 #include "../include/NDTime.hpp"
 
 
@@ -381,6 +382,33 @@ BOOST_AUTO_TEST_SUITE( deepView )
         out << h; BOOST_CHECK_EQUAL(out.str(),dv_expected_h); out.str(""); out.clear();
         NDTime::stopDeepView();
         out << h; BOOST_CHECK_EQUAL(out.str(),sv_expected_h); out.str(""); out.clear();
+    }
+
+    BOOST_AUTO_TEST_CASE( unordered_map ) {
+        std::stringstream out;
+        auto m = std::unordered_map<NDTime, std::string>();
+
+        NDTime a({10,5,10,105,10,105,10,10});
+        NDTime b({10,5,10,105,10,105,10});
+        NDTime c({10,5,10,105,10,105});
+
+        std::string a_first = "Hello";
+        std::string b_first = "World";
+        std::string c_first = "!";
+        std::string a_last = "Goodbye";
+
+        m[a] = a_first;
+        m[b] = b_first;
+
+        out << m.at(a); BOOST_CHECK_EQUAL(out.str(),a_first); out.str(""); out.clear();
+        out << m.at(b); BOOST_CHECK_EQUAL(out.str(),b_first); out.str(""); out.clear();
+        BOOST_CHECK_THROW(m.at(c), std::out_of_range);
+        m[a] = a_last;
+        auto res = m.erase(b); BOOST_CHECK_EQUAL(1, res);
+        m[c] = c_first;
+        out << m.at(a); BOOST_CHECK_EQUAL(out.str(),a_last); out.str(""); out.clear();
+        BOOST_CHECK_THROW(m.at(b), std::out_of_range);
+        out << m.at(c); BOOST_CHECK_EQUAL(out.str(),c_first); out.str(""); out.clear();
     }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I've added a couple of functions to enable hashing DES time classes. Thus, now we can use these classes as keys for `std::map` and `std::unordered_map` structures, for instance.